### PR TITLE
Fix bug with /start command

### DIFF
--- a/mods/tug_core/init.lua
+++ b/mods/tug_core/init.lua
@@ -651,7 +651,7 @@ local function start_game(name, param, unexpected)
 	local player2 = t[1]
 
 	if player2 ~= "" then
-		local p = minetest.get_player_by_name("playername")
+		local p = minetest.get_player_by_name(player2)
 		if p then
 			tug_gamestate.g.players[2] = {name = player2, color = 2}
 		else


### PR DESCRIPTION
Fixed a bug where running `/start [player name]` would always get `[ERROR] Requested opponent couldn't be found. Try again!`.

This was caused by line 654 in `mods/tug_core/init.lua`, where the code checks if a player named "playername" exists, rather than checking the actual player name given to the `/start` command.